### PR TITLE
Make steamstatic noisy

### DIFF
--- a/lua/cfc_http_restrictions/default_config.lua
+++ b/lua/cfc_http_restrictions/default_config.lua
@@ -33,7 +33,7 @@ local config = {
         ["api.steampowered.com"] = { allowed = true },
         ["steamcommunity.com"] = { allowed = true },
         ["developer.valvesoftware.com"] = { allowed = true },
-        ["*.steamstatic.com"] = { allowed = true },
+        ["*.steamstatic.com"] = { allowed = true, noisy = true },
         ["images.steamusercontent.com"] = { allowed = true },
         ["steamuserimages-a.akamaihd.net"] = { allowed = true },
         ["images.akamai.steamusercontent.com"] = { allowed = true },


### PR DESCRIPTION
Addons that fetch a lot of profile pictures do a lot of requests while logging these requests isn't very useful